### PR TITLE
Add Item BindingContext for IndicatorsControl base on Parent.Items

### DIFF
--- a/PanCardView/Controls/IndicatorsControl.cs
+++ b/PanCardView/Controls/IndicatorsControl.cs
@@ -114,10 +114,16 @@ namespace PanCardView.Controls
 
 		protected virtual void AddExtraIndicatorsItems()
 		{
+            var cardsView = BindingContext as CardsView;
+
 			var oldCount = Children.Count;
 			for (var i = 0; i < ItemsCount - oldCount; ++i)
 			{
 				var item = ItemTemplate.CreateView();
+                if(cardsView != null)
+                {
+                    item.BindingContext = cardsView.Items[i];
+                }
 				AddItemTapGesture(item);
 				Children.Add(item);
 			}


### PR DESCRIPTION
Hi @AndreiMisiukevich,
I added the BindingContext for Items of IndicatorsControl so that I can use the ItemTemplate more flexible. For example, I can apply this template for Thumbnail purpose:
```
<controls:IndicatorsControl>
            <controls:IndicatorsControl.ItemTemplate>
                <DataTemplate>
                    <ContentView>
                        <Frame 
                        VerticalOptions="Center"
                        HorizontalOptions="Center"
                        HeightRequest="40"
                        WidthRequest="40"
                        Padding="0" 
                        HasShadow="false"
                        IsClippedToBounds="true"
                        CornerRadius="10"
                        BackgroundColor="{Binding Color}">

                            <ffimage:CachedImage Source="{Binding Source}"/>

                        </Frame>
                    </ContentView>
                </DataTemplate>
            </controls:IndicatorsControl.ItemTemplate>
        </controls:IndicatorsControl>
```

Please review and merge if you think it's adequate. Otherwise, I will create other IndicatorsControl in my project.