### PR TITLE
Fixed a bug with an incorrect animation direction when skipping a card

### DIFF
--- a/PanCardView/CardsView.cs
+++ b/PanCardView/CardsView.cs
@@ -807,6 +807,12 @@ namespace PanCardView
             var oldRecIndex = OldIndex.ToCyclingIndex(ItemsCount);
 
             var deltaIndex = recIndex - oldRecIndex;
+
+            if (recIndex == SelectedIndex && oldRecIndex == OldIndex)
+            {
+                return recIndex > oldRecIndex ? AnimationDirection.Next : AnimationDirection.Prev;
+            }
+
             if (Abs(deltaIndex) == 1)
             {
                 return deltaIndex > 0


### PR DESCRIPTION
I'm testing your library and noticed that there is a bug in the animation direction. 

E.g. there are 10 items in the carousel. SelectedIndex == 2. I want to jump to the 5th card. When I set SelectedIndex = 5 I see that the animation direction is Prev. 

Fixing.