### PR TITLE
Change OnSwipe to virtual to override method

### DIFF
--- a/PanCardView/CardsView.cs
+++ b/PanCardView/CardsView.cs
@@ -494,7 +494,7 @@ namespace PanCardView
             }
         }
 
-        public void OnSwiped(ItemSwipeDirection swipeDirection)
+        public virtual void OnSwiped(ItemSwipeDirection swipeDirection)
         {
             if (!IsUserInteractionEnabled || !_isPanEndRequested || !CheckInteractionDelay())
             {


### PR DESCRIPTION
There are some obstacles when trying to modify the swipe event when the IsPanSwipeEnabled equals to false you can't trigger the ItemSwiped and needed to modify the behavior of the OnSwiped to be able to reactivate the IsPanSwipeEnabled. In this case the OnSwipe is virtual so can be override to change the original behavior.