### PR TITLE
Added support for XF IndicatorView

### DIFF
--- a/PanCardView/CardsView.cs
+++ b/PanCardView/CardsView.cs
@@ -144,28 +144,29 @@ namespace PanCardView
         internal static readonly BindableProperty ShouldAutoNavigateToNextProperty = BindableProperty.Create(nameof(ShouldAutoNavigateToNext), typeof(bool?), typeof(CardsView), null);
 
         internal static readonly BindableProperty ProcessorDiffProperty = BindableProperty.Create(nameof(ProcessorDiff), typeof(double), typeof(CardsView), 0.0, BindingMode.OneWayToSource);
+
         [Xamarin.Forms.TypeConverter(typeof(ReferenceTypeConverter))]
         public IndicatorView IndicatorView
         {
-            set => LinkToIndicatorView(this, value);
-        }
-
-        static void LinkToIndicatorView(CardsView cardsView, IndicatorView indicatorView)
-        {
-            if (indicatorView == null)
-                return;
-
-            indicatorView.SetBinding(IndicatorView.PositionProperty, new Binding
+            set
             {
-                Path = nameof(SelectedIndex),
-                Source = cardsView
-            });
-
-            indicatorView.SetBinding(IndicatorView.ItemsSourceProperty, new Binding
-            {
-                Path = nameof(ItemsView.ItemsSource),
-                Source = cardsView
-            });
+                if (value == null) 
+                {
+                    return;
+                }
+                
+                value.SetBinding(IndicatorView.PositionProperty, new Binding
+                {
+                    Path = nameof(SelectedIndex),
+                    Source = this
+                });
+                
+                value.SetBinding(IndicatorView.ItemsSourceProperty, new Binding
+                {
+                    Path = nameof(ItemsView.ItemsSource),
+                    Source = this
+                });
+            }
         }
 
         public event CardsViewUserInteractedHandler UserInteracted;

--- a/PanCardView/CardsView.cs
+++ b/PanCardView/CardsView.cs
@@ -144,6 +144,29 @@ namespace PanCardView
         internal static readonly BindableProperty ShouldAutoNavigateToNextProperty = BindableProperty.Create(nameof(ShouldAutoNavigateToNext), typeof(bool?), typeof(CardsView), null);
 
         internal static readonly BindableProperty ProcessorDiffProperty = BindableProperty.Create(nameof(ProcessorDiff), typeof(double), typeof(CardsView), 0.0, BindingMode.OneWayToSource);
+        [Xamarin.Forms.TypeConverter(typeof(ReferenceTypeConverter))]
+        public IndicatorView IndicatorView
+        {
+            set => LinkToIndicatorView(this, value);
+        }
+
+        static void LinkToIndicatorView(CardsView cardsView, IndicatorView indicatorView)
+        {
+            if (indicatorView == null)
+                return;
+
+            indicatorView.SetBinding(IndicatorView.PositionProperty, new Binding
+            {
+                Path = nameof(SelectedIndex),
+                Source = cardsView
+            });
+
+            indicatorView.SetBinding(IndicatorView.ItemsSourceProperty, new Binding
+            {
+                Path = nameof(ItemsView.ItemsSource),
+                Source = cardsView
+            });
+        }
 
         public event CardsViewUserInteractedHandler UserInteracted;
         public event CardsViewItemDisappearingHandler ItemDisappearing;

--- a/PanCardViewSample/PanCardViewSample/PanCardViewSample.cs
+++ b/PanCardViewSample/PanCardViewSample/PanCardViewSample.cs
@@ -77,7 +77,7 @@ namespace PanCardViewSample
                 this.Navigation.PushAsync(new CubeSampleXamlView());
             };
 
-            var toXFIndicatorViewBtn = new Button { Text = "XF indicator view", FontSize = 20, TextColor = Color.Black };
+            var toXFIndicatorViewBtn = new Button { Text = "XF IndicatorView" };
             toXFIndicatorViewBtn.Clicked += (sender, e) =>
             {
                 this.Navigation.PushAsync(new CarouselSampleXamlViewXFIndicatorView());

--- a/PanCardViewSample/PanCardViewSample/PanCardViewSample.cs
+++ b/PanCardViewSample/PanCardViewSample/PanCardViewSample.cs
@@ -77,6 +77,12 @@ namespace PanCardViewSample
                 this.Navigation.PushAsync(new CubeSampleXamlView());
             };
 
+            var toXFIndicatorViewBtn = new Button { Text = "XF indicator view", FontSize = 20, TextColor = Color.Black };
+            toXFIndicatorViewBtn.Clicked += (sender, e) =>
+            {
+                this.Navigation.PushAsync(new CarouselSampleXamlViewXFIndicatorView());
+            };
+
             Content = new ScrollView
 			{
 				Content = new StackLayout
@@ -91,7 +97,8 @@ namespace PanCardViewSample
 						toCarouselScrollBtn,
 						toCarouselNoTemplateBtn,
 						toCarouselListBtn,
-						toCarouselEmbBtn
+						toCarouselEmbBtn,
+                        toXFIndicatorViewBtn
                     }
 				}
 			};

--- a/PanCardViewSample/PanCardViewSample/PanCardViewSample.csproj
+++ b/PanCardViewSample/PanCardViewSample/PanCardViewSample.csproj
@@ -14,4 +14,9 @@
     <Compile Remove="ViewModels\CoverFlowViewModel.cs" />
     <Compile Remove="Views\CoverFlowSampleView.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Views\CarouselSampleXamlViewXFIndicatorView.xaml.cs">
+      <DependentUpon>CarouselSampleXamlViewXFIndicatorView.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/PanCardViewSample/PanCardViewSample/PanCardViewSample.csproj
+++ b/PanCardViewSample/PanCardViewSample/PanCardViewSample.csproj
@@ -14,9 +14,4 @@
     <Compile Remove="ViewModels\CoverFlowViewModel.cs" />
     <Compile Remove="Views\CoverFlowSampleView.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Update="Views\CarouselSampleXamlViewXFIndicatorView.xaml.cs">
-      <DependentUpon>CarouselSampleXamlViewXFIndicatorView.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
 </Project>

--- a/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml
+++ b/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml
@@ -50,7 +50,7 @@
         <IndicatorView x:Name="indicatorView"
                        Margin="10"
                        HorizontalOptions="Center"
-                       IndicatorColor="Blue"
+                       IndicatorColor="LightGray"
                        SelectedIndicatorColor="DarkGray" />
 
     </StackLayout>

--- a/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml
+++ b/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage x:Class="PanCardViewSample.Views.CarouselSampleXamlViewXFIndicatorView"
+             xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:cards="clr-namespace:PanCardView;assembly=PanCardView"
+             xmlns:controls="clr-namespace:PanCardView.Controls;assembly=PanCardView"
+             xmlns:ffimage="clr-namespace:FFImageLoading.Forms;assembly=FFImageLoading.Forms"
+             xmlns:proc="clr-namespace:PanCardView.Processors;assembly=PanCardView"
+             xmlns:viewModels="clr-namespace:PanCardViewSample.ViewModels"
+             Title="Carousel Xaml"
+             BackgroundColor="Black">
+
+    <ContentPage.BindingContext>
+        <viewModels:CardsSampleViewModel />
+    </ContentPage.BindingContext>
+    <StackLayout>
+        <cards:CarouselView IndicatorView="indicatorView"
+                            ItemsSource="{Binding Items}"
+                            SelectedIndex="{Binding CurrentIndex}"
+                            SlideShowDuration="3500">
+
+            <x:Arguments>
+                <proc:CarouselProcessor OpacityFactor="0"
+                                        RotationFactor="0.1"
+                                        ScaleFactor="0.5" />
+            </x:Arguments>
+
+            <cards:CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <ContentView>
+                        <Frame Padding="0"
+                               BackgroundColor="{Binding Color}"
+                               CornerRadius="10"
+                               HasShadow="false"
+                               HeightRequest="300"
+                               HorizontalOptions="Center"
+                               IsClippedToBounds="true"
+                               VerticalOptions="Center"
+                               WidthRequest="300">
+
+                            <ffimage:CachedImage Source="{Binding Source}" />
+
+                        </Frame>
+                    </ContentView>
+                </DataTemplate>
+            </cards:CarouselView.ItemTemplate>
+            <controls:LeftArrowControl ToFadeDuration="2500" />
+            <controls:RightArrowControl ToFadeDuration="2500" />
+        </cards:CarouselView>
+        <IndicatorView x:Name="indicatorView"
+                       Margin="10"
+                       HorizontalOptions="Center"
+                       IndicatorColor="Blue"
+                       SelectedIndicatorColor="DarkGray" />
+
+    </StackLayout>
+</ContentPage>

--- a/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml.cs
+++ b/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 using Xamarin.Forms;
@@ -9,9 +9,9 @@ namespace PanCardViewSample.Views
     [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class CarouselSampleXamlViewXFIndicatorView : ContentPage
     {
-		public CarouselSampleXamlViewXFIndicatorView()
-		{
-			InitializeComponent();
+        public CarouselSampleXamlViewXFIndicatorView()
+        {
+            InitializeComponent();
         }
     }
 }

--- a/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml.cs
+++ b/PanCardViewSample/PanCardViewSample/Views/CarouselSampleXamlViewXFIndicatorView.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace PanCardViewSample.Views
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class CarouselSampleXamlViewXFIndicatorView : ContentPage
+    {
+		public CarouselSampleXamlViewXFIndicatorView()
+		{
+			InitializeComponent();
+        }
+    }
+}

--- a/PanCardViewSample/iOS/PanCardViewSample.iOS.csproj
+++ b/PanCardViewSample/iOS/PanCardViewSample.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Xamarin.Forms.5.0.0.2012\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.5.0.0.2012\build\Xamarin.Forms.props')" />
   <PropertyGroup>
@@ -115,15 +115,19 @@
     <ProjectReference Include="..\..\PanCardView.iOS\PanCardView.iOS.csproj">
       <Project>{00BA6657-0102-46EC-B936-1512FA8BBD92}</Project>
       <Name>PanCardView.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" />
   </ItemGroup>

--- a/PanCardViewSample/iOS/PanCardViewSample.iOS.csproj
+++ b/PanCardViewSample/iOS/PanCardViewSample.iOS.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Xamarin.Forms.5.0.0.2012\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.5.0.0.2012\build\Xamarin.Forms.props')" />
   <PropertyGroup>
@@ -115,19 +115,15 @@
     <ProjectReference Include="..\..\PanCardView.iOS\PanCardView.iOS.csproj">
       <Project>{00BA6657-0102-46EC-B936-1512FA8BBD92}</Project>
       <Name>PanCardView.iOS</Name>
-      <IsAppExtension>false</IsAppExtension>
-      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
-      <Visible>false</Visible>
-    </ImageAsset>
-    <ImageAsset Include="Assets.xcassets\Contents.json">
-      <Visible>false</Visible>
-    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\Contents.json" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" />
   </ItemGroup>


### PR DESCRIPTION
Added support for XF [IndicatorView](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/user-interface/indicatorview). 

Copied the implementation from the XF [carousel control](https://github.com/xamarin/Xamarin.Forms/blob/caab66bcf9614aca0c0805d560a34e176d196e17/Xamarin.Forms.Core/Items/CarouselView.cs#L160).

Tested on Android and iOS.

I know this project has its own implementation, but the reason I added this is because it makes it easier to transition from XF carousel control to this control, + if an app already utilizing the IndicatorView elsewhere in the app, rather than trying to match the design, they can just reuse the code they already have. 
