### PR TITLE
Add ShouldBegin gesture recognizer check for iOS

### DIFF
--- a/PanCardView.iOS/CardsViewRenderer.cs
+++ b/PanCardView.iOS/CardsViewRenderer.cs
@@ -50,7 +50,7 @@ namespace PanCardView.iOS
             {
                 gestureRecognizer.ShouldBeRequiredToFailBy = ShouldBeRequiredToFailBy;
                 gestureRecognizer.ShouldRecognizeSimultaneously = ShouldRecognizeSimultaneously;
-                gestureRecognizer.ShouldBegin = ShouldBeginPan;
+                gestureRecognizer.ShouldBegin = ShouldBegin;
             }
         }
 
@@ -122,12 +122,16 @@ namespace PanCardView.iOS
             Element?.OnSwiped(swipeDirection);
         }
 
-        private bool ShouldBeginPan(UIGestureRecognizer recognizer)
+        private bool ShouldBegin(UIGestureRecognizer recognizer)
         {
-            if (recognizer is UIPanGestureRecognizer pangesture && !Element.IsVerticalSwipeEnabled)
+            if (recognizer is UIPanGestureRecognizer pangesture)
             {
                 var velocity = pangesture.VelocityInView(this);
-                return Abs(velocity.X) > Abs(velocity.Y);
+                var absVelocityX = Abs(velocity.X);
+                var absVelocityY = Abs(velocity.Y);
+                var isHorizontal = Element.IsHorizontalOrientation;
+                return (absVelocityY < absVelocityX && isHorizontal) ||
+                       (absVelocityY > absVelocityX && !isHorizontal);
             }
 
             return true;

--- a/PanCardView.iOS/CardsViewRenderer.cs
+++ b/PanCardView.iOS/CardsViewRenderer.cs
@@ -50,6 +50,7 @@ namespace PanCardView.iOS
             {
                 gestureRecognizer.ShouldBeRequiredToFailBy = ShouldBeRequiredToFailBy;
                 gestureRecognizer.ShouldRecognizeSimultaneously = ShouldRecognizeSimultaneously;
+                gestureRecognizer.ShouldBegin = ShouldBeginPan;
             }
         }
 
@@ -119,6 +120,17 @@ namespace PanCardView.iOS
                         : ItemSwipeDirection.Down;
 
             Element?.OnSwiped(swipeDirection);
+        }
+
+        private bool ShouldBeginPan(UIGestureRecognizer recognizer)
+        {
+            if (recognizer is UIPanGestureRecognizer pangesture && !Element.IsVerticalSwipeEnabled)
+            {
+                var velocity = pangesture.VelocityInView(this);
+                return Abs(velocity.X) > Abs(velocity.Y);
+            }
+
+            return true;
         }
 
         private bool ShouldBeRequiredToFailBy(UIGestureRecognizer gestureRecognizer, UIGestureRecognizer otherGestureRecognizer)

--- a/PanCardViewSample/iOS/PanCardViewSample.iOS.csproj
+++ b/PanCardViewSample/iOS/PanCardViewSample.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Xamarin.Forms.5.0.0.2012\build\Xamarin.Forms.props" Condition="Exists('..\packages\Xamarin.Forms.5.0.0.2012\build\Xamarin.Forms.props')" />
   <PropertyGroup>
@@ -115,15 +115,19 @@
     <ProjectReference Include="..\..\PanCardView.iOS\PanCardView.iOS.csproj">
       <Project>{8D8B85B4-6F23-49B6-A188-91BBBBF51EF6}</Project>
       <Name>PanCardView.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
-    <ImageAsset Include="Assets.xcassets\Contents.json" />
+    <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
+    <ImageAsset Include="Assets.xcassets\Contents.json">
+      <Visible>false</Visible>
+    </ImageAsset>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <InterfaceDefinition Include="LaunchScreen.storyboard" />
   </ItemGroup>


### PR DESCRIPTION
This fixes the iOS accidental horizontal scroll when a CarouselView item contains a scrollable view (like CollectionView).
Brings the behavior in line with what happens on Android.

as described in #382 

Seems like my visual studio for windows made some fixes of it's own - lines endings + project file format.